### PR TITLE
fix: updated github_checksum.py to use env python instead of system

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 namespace: bodsch
 name: scm
 
-version: 0.9.6
+version: 0.9.7
 
 readme: README.md
 

--- a/plugins/modules/github_checksum.py
+++ b/plugins/modules/github_checksum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, print_function

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
 ansible-lint
+ansible-compat < 4.0.1
 docker
 flake8
-molecule
+molecule < 5.0.0
 molecule-plugins[docker]
 netaddr
 pytest


### PR DESCRIPTION
We ran into an issue where github_checksum.py uses the system path python instead of the working virtual environemnt when running in ansible due to the shebang path. This created issues with trying to maintain dependencies with poetry for the packaging python package. This fix resolve the issue.

I also had to add some version constraints to the test-requirements.yml due to major version changes in molecule and test dependencies.