### PR TITLE
Add a few missing settings

### DIFF
--- a/roles/forgejo/tasks/authentications.yml
+++ b/roles/forgejo/tasks/authentications.yml
@@ -26,6 +26,7 @@
     password: "{{ forgejo_admin_user.password }}"
     email: "{{ forgejo_admin_user.email }}"
   when:
+    - not ansible_check_mode
     - forgejo_admin_user_present.rc == 1
     - (forgejo_admin_user.username is defined and forgejo_admin_user.username | string | length > 0)
     - (forgejo_admin_user.password is defined and forgejo_admin_user.password | string | length > 0)

--- a/roles/forgejo/tasks/configure.yml
+++ b/roles/forgejo/tasks/configure.yml
@@ -29,6 +29,7 @@
     - data
     - data/forgejo-repositories
     - data/lfs
+    - data/packages
     - data/home
 
 - name: create forgejo configuration

--- a/roles/forgejo/templates/conf/forgejo.d/actions.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/actions.j2
@@ -9,3 +9,16 @@ DEFAULT_ACTIONS_URL = {{ forgejo_actions.default_actions_url }}
         forgejo_actions.artifact_retention_days | string | length > 0 %}
 ARTIFACT_RETENTION_DAYS = {{ forgejo_actions.artifact_retention_days }}
   {% endif %}
+  {% if forgejo_actions.zombie_task_timeout | default('') | string | length > 0 %}
+ZOMBIE_TASK_TIMEOUT: {{ forgejo_actions.zombie_task_timeout }}
+  {% endif %}
+  {% if forgejo_actions.endless_task_timeout | default('') | string | length > 0 %}
+ENDLESS_TASK_TIMEOUT: {{ forgejo_actions.endless_task_timeout }}
+  {% endif %}
+  {% if forgejo_actions.abandoned_job_timeout | default('') | string | length > 0 %}
+ABANDONED_JOB_TIMEOUT: {{ forgejo_actions.abandoned_job_timeout }}
+  {% endif %}
+  {% if forgejo_actions.skip_workflow_strings is defined and
+        forgejo_actions.skip_workflow_strings | count > 0 %}
+SKIP_WORKFLOW_STRINGS: {{ forgejo_actions.skip_workflow_strings | join(', ') }}
+  {% endif %}

--- a/roles/forgejo/templates/conf/forgejo.d/admin.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/admin.j2
@@ -7,3 +7,14 @@ DISABLE_REGULAR_ORG_CREATION = {{ forgejo_admin.disable_regular_org_creation | b
         forgejo_admin.default_email_notifications in ["enabled", "onmention", "disabled"] %}
 DEFAULT_EMAIL_NOTIFICATIONS = {{ forgejo_admin.default_email_notifications }}
   {% endif %}
+  {% if forgejo_admin.user_disabled_features is defined and
+        forgejo_admin.user_disabled_features | count > 0 %}
+USER_DISABLED_FEATURES = {{ forgejo_admin.user_disabled_features | join(', ') }}
+  {% endif %}
+  {% if forgejo_admin.external_user_disable_features is defined and
+        forgejo_admin.external_user_disable_features | count > 0 %}
+EXTERNAL_USER_DISABLE_FEATURES = {{ forgejo_admin.external_user_disable_features | join(', ') }}
+  {% endif %}
+  {% if forgejo_admin.send_notification_email_on_new_user | default('') | string | length > 0 %}
+SEND_NOTIFICATION_EMAIL_ON_NEW_USER = {{ forgejo_admin.send_notification_email_on_new_user | bodsch.core.config_bool(true_as='true', false_as='false') }}
+  {% endif %}

--- a/roles/forgejo/templates/conf/forgejo.d/lfs.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/lfs.j2
@@ -27,5 +27,15 @@ MINIO_BUCKET = {{ forgejo_lfs.minio_bucket }}
     {% if forgejo_lfs.minio_location | default('') | string | length > 0 %}
 MINIO_LOCATION = {{ forgejo_lfs.minio_location }}
     {% endif %}
+    {% if forgejo_lfs.minio_use_ssl | default('') | string | length > 0 %}
+MINIO_USE_SSL = {{ forgejo_lfs.minio_use_ssl | bool | ternary('true', 'false') }}
+    {% endif %}
+    {% if forgejo_lfs.minio_insecure_skip_verify | default('') | string | length > 0 %}
+MINIO_INSECURE_SKIP_VERIFY = {{ forgejo_lfs.minio_insecure_skip_verify | bool | ternary('true', 'false') }}
+    {% endif %}
+    {% if forgejo_lfs.minio_checksum_algorithm | default('') | string | length > 0 and
+          forgejo_lfs.minio_checksum_algorithm in ["default", "md5"] %}
+MINIO_CHECKSUM_ALGORITHM = {{ forgejo_lfs.minio_checksum_algorithm }}
+    {% endif %}
   {% endif %}
 {% endif %}

--- a/roles/forgejo/templates/conf/forgejo.d/oauth2.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/oauth2.j2
@@ -1,6 +1,6 @@
 
 [oauth2]
-ENABLE = {{ forgejo_oauth2.enabled | default('false') | bodsch.core.config_bool(true_as='true', false_as='false') }}
+ENABLED = {{ forgejo_oauth2.enabled | default('false') | bodsch.core.config_bool(true_as='true', false_as='false') }}
   {% if forgejo_oauth2.jwt_signing_algorithm | default('') | string | length > 0 and
         forgejo_oauth2.jwt_signing_algorithm in ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "EdDSA"] %}
 JWT_SIGNING_ALGORITHM = {{ forgejo_oauth2.jwt_signing_algorithm }}

--- a/roles/forgejo/templates/conf/forgejo.d/packages.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/packages.j2
@@ -58,3 +58,41 @@ LIMIT_SIZE_SWIFT = {{ forgejo_packages.limit_size_swift }}
   {% if forgejo_packages.limit_size_vagrant | default('') | string | length > 0 %}
 LIMIT_SIZE_VAGRANT = {{ forgejo_packages.limit_size_vagrant }}
   {% endif %}
+{% if forgejo_packages.storage_type | default('') | string | length > 0 and
+      forgejo_packages.storage_type in ["local", "minio"] %}
+STORAGE_TYPE = {{ forgejo_packages.storage_type }}
+  {% if forgejo_packages.storage_type == "local" %}
+    {% if forgejo_packages.path | default('') | string | length > 0 %}
+PATH = {{ forgejo_packages.path }}
+    {% endif %}
+  {% endif %}
+  {% if forgejo_packages.storage_type == "minio" %}
+    {% if forgejo_packages.minio_base_path | default('') | string | length > 0 %}
+MINIO_BASE_PATH = {{ forgejo_packages.minio_base_path }}
+    {% endif %}
+    {% if forgejo_packages.minio_endpoint | default('') | string | length > 0 %}
+MINIO_ENDPOINT = {{ forgejo_packages.minio_endpoint }}
+    {% endif %}
+    {% if forgejo_packages.minio_access_key_id | default('') | string | length > 0 %}
+MINIO_ACCESS_KEY_ID = {{ forgejo_packages.minio_access_key_id }}
+    {% endif %}
+    {% if forgejo_packages.minio_secret_access_key | default('') | string | length > 0 %}
+MINIO_SECRET_ACCESS_KEY = {{ forgejo_packages.minio_secret_access_key }}
+    {% endif %}
+    {% if forgejo_packages.minio_bucket | default('') | string | length > 0 %}
+MINIO_BUCKET = {{ forgejo_packages.minio_bucket }}
+    {% endif %}
+    {% if forgejo_packages.minio_location | default('') | string | length > 0 %}
+MINIO_LOCATION = {{ forgejo_packages.minio_location }}
+    {% endif %}
+    {% if forgejo_packages.minio_use_ssl | default('') | string | length > 0 %}
+MINIO_USE_SSL = {{ forgejo_packages.minio_use_ssl | bool | ternary('true', 'false') }}
+    {% endif %}
+    {% if forgejo_packages.minio_insecure_skip_verify | default('') | string | length > 0 %}
+MINIO_INSECURE_SKIP_VERIFY = {{ forgejo_packages.minio_insecure_skip_verify | bool | ternary('true', 'false') }}
+    {% endif %}
+    {% if forgejo_packages.minio_checksum_algorithm | default('') | string | length > 0 and
+          forgejo_packages.minio_checksum_algorithm in ["default", "md5"] %}
+MINIO_CHECKSUM_ALGORITHM = {{ forgejo_packages.minio_checksum_algorithm }}
+    {% endif %}  {% endif %}
+{% endif %}

--- a/roles/forgejo/templates/conf/forgejo.d/storage.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/storage.j2
@@ -34,6 +34,9 @@ MINIO_USE_SSL = {{ forgejo_storage.minio_use_ssl | bodsch.core.config_bool(true_
     {% if forgejo_storage.minio_insecure_skip_verify | default('') | string | length > 0 %}
 MINIO_INSECURE_SKIP_VERIFY = {{ forgejo_storage.minio_insecure_skip_verify | bodsch.core.config_bool(true_as='true', false_as='false') }}
     {% endif %}
+    {% if forgejo_storage.minio_checksum_algorithm | default('') | string | length > 0 %}
+MINIO_CHECKSUM_ALGORITHM = {{ forgejo_storage.minio_checksum_algorithm | bodsch.core.config_bool(true_as='true', false_as='false') }}
+    {% endif %}
   {% endif %}
   {% if forgejo_storage.repo_archive is defined and
         forgejo_storage.repo_archive | count > 0 %}

--- a/roles/forgejo/vars/main.yml
+++ b/roles/forgejo/vars/main.yml
@@ -30,6 +30,9 @@ forgejo_defaults_actions:
 forgejo_defaults_admin:
   disable_regular_org_creation: ""                # false
   default_email_notifications: ""                 # enabled
+  user_disabled_features: []
+  external_user_disable_features: []
+  send_notification_email_on_new_user: ""
 
 forgejo_defaults_api:
   enable_swagger: ""                              # true

--- a/roles/forgejo/vars/main.yml
+++ b/roles/forgejo/vars/main.yml
@@ -22,6 +22,10 @@ forgejo_defaults_actions:
   enabled: false
   default_actions_url: ""
   artifact_retention_days: ""                     # 90
+  zombie_task_timeout: ""
+  endless_task_timeout: ""
+  abandoned_job_timeout: ""
+  skip_workflow_strings: []
 
 forgejo_defaults_admin:
   disable_regular_org_creation: ""                # false

--- a/roles/forgejo/vars/main.yml
+++ b/roles/forgejo/vars/main.yml
@@ -589,6 +589,17 @@ forgejo_defaults_packages:
   limit_size_rubygems: ""                         # -1
   limit_size_swift: ""                            # -1
   limit_size_vagrant: ""                          # -1
+  storage_type: "local"                           # local, minio
+  path: ""                                        # data/packages
+  minio_base_path: ""
+  minio_endpoint: ""
+  minio_access_key_id: ""
+  minio_secret_access_key: ""
+  minio_bucket: ""
+  minio_location: ""
+  minio_use_ssl: ""
+  minio_insecure_skip_verify: ""
+  minio_checksum_algorithm: ""
 
 forgejo_defaults_picture:
   avatar_upload_path: ""                          # data/avatars

--- a/roles/forgejo/vars/main.yml
+++ b/roles/forgejo/vars/main.yml
@@ -411,6 +411,9 @@ forgejo_defaults_lfs:
   minio_secret_access_key: ""
   minio_bucket: ""
   minio_location: ""
+  minio_use_ssl: ""
+  minio_insecure_skip_verify: ""
+  minio_checksum_algorithm: ""
 
 forgejo_defaults_log:
   root_path: ""
@@ -905,6 +908,7 @@ forgejo_defaults_storage:
   minio_location: ""                            # us-east-1
   minio_use_ssl: ""                             # false
   minio_insecure_skip_verify: ""                # false
+  minio_checksum_algorithm: ""                  # false
   repo_archive:
     storage_type: ""                              # local
   packages:


### PR DESCRIPTION
This PR adds a few missing settings.

- packages now have storage settings. This resolves an issue where without any settings package uploads would simply fail
- LFS storage now has complete Minio settings, since without these LFS would fail in a non HTTP scenario
- OAuth enablement no longer uses deprecated flag
- generic storage settings can now have checksum algorithm
- actions can now be fully configured
- admin con now be fully configured

Hope this helps, we're using these changes in production already and these fixes resolve a few issues preventing Forgejo from properly working for us.
