### PR TITLE
Consistently apply config and working_dir when calling modules

### DIFF
--- a/roles/forgejo/handlers/main.yml
+++ b/roles/forgejo/handlers/main.yml
@@ -30,6 +30,7 @@
   become: true
   bodsch.scm.forgejo_migrate:
     config: "{{ forgejo_config_dir }}/forgejo.ini"
+    working_dir: "{{ forgejo_working_dir }}"
 
 - name: check if forgejo are available
   ansible.builtin.wait_for:

--- a/roles/forgejo/molecule/custom-config-directory/converge.yml
+++ b/roles/forgejo/molecule/custom-config-directory/converge.yml
@@ -1,0 +1,9 @@
+---
+
+- name: converge
+  hosts: instance
+  any_errors_fatal: false
+  become: false
+
+  roles:
+    - role: bodsch.scm.forgejo

--- a/roles/forgejo/molecule/custom-config-directory/group_vars/all/vars.yml
+++ b/roles/forgejo/molecule/custom-config-directory/group_vars/all/vars.yml
@@ -1,0 +1,10 @@
+---
+forgejo_config_dir: /srv/forgejo/config
+forgejo_working_dir: /srv/forgejo
+
+forgejo_admin_user:
+  username: "someuser"
+  password: "foo"
+  email: "root@example.com"
+
+...

--- a/roles/forgejo/molecule/custom-config-directory/molecule.yml
+++ b/roles/forgejo/molecule/custom-config-directory/molecule.yml
@@ -1,0 +1,59 @@
+---
+
+role_name_check: 1
+
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: "ghcr.io/bodsch/docker-ansible/ansible-${DISTRIBUTION:-debian:12}"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    docker_host: "${DOCKER_HOST:-unix://run/docker.sock}"
+    privileged: true
+    pre_build_image: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /var/lib/containerd
+    capabilities:
+      - SYS_ADMIN
+    tmpfs:
+      - /run
+      - /tmp
+    published_ports:
+      - 80:80
+      - 443:443
+      - 3000:3000
+
+provisioner:
+  name: ansible
+  ansible_args:
+    - --diff
+    - -v
+  config_options:
+    defaults:
+      deprecation_warnings: true
+      callback_result_format: yaml
+      callbacks_enabled: profile_tasks
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_timeout: 8640
+      fact_caching_connection: ansible_facts
+
+scenario:
+  test_sequence:
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy
+
+verifier:
+  name: testinfra

--- a/roles/forgejo/molecule/custom-config-directory/prepare.yml
+++ b/roles/forgejo/molecule/custom-config-directory/prepare.yml
@@ -1,0 +1,55 @@
+---
+
+- name: information
+  hosts: all
+  gather_facts: true
+
+  pre_tasks:
+    - name: arch- / artixlinux
+      when:
+        - ansible_distribution | lower == 'archlinux' or
+          ansible_os_family | lower == 'artix linux'
+      block:
+        - name: update pacman system
+          ansible.builtin.command: |
+            pacman --refresh --sync --sysupgrade --noconfirm
+          register: pacman
+          changed_when: pacman.rc != 0
+          failed_when: pacman.rc != 0
+
+        - name: create depends service
+          ansible.builtin.copy:
+            mode: 0755
+            dest: /etc/init.d/net
+            content: |
+              #!/usr/bin/openrc-run
+              true
+          when:
+            - ansible_os_family | lower == 'artix linux'
+
+    - name: make sure python3-apt is installed (only debian based)
+      ansible.builtin.package:
+        name:
+          - python3-apt
+        state: present
+      when:
+        - ansible_os_family | lower == 'debian'
+
+    - name: update package cache
+      become: true
+      ansible.builtin.package:
+        update_cache: true
+
+    - name: install dependencies
+      ansible.builtin.package:
+        name:
+          - iproute2
+        state: present
+
+    - name: environment
+      ansible.builtin.debug:
+        msg:
+          - "os family            : {{ ansible_distribution }} ({{ ansible_os_family }})"
+          - "distribution version : {{ ansible_distribution_major_version }}"
+          - "ansible version      : {{ ansible_version.full }}"
+          - "python version       : {{ ansible_python.version.major }}.{{ ansible_python.version.minor }}"

--- a/roles/forgejo/molecule/custom-config-directory/tests/test_default.py
+++ b/roles/forgejo/molecule/custom-config-directory/tests/test_default.py
@@ -1,0 +1,190 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar
+
+import json
+import pytest
+import os
+
+import testinfra.utils.ansible_runner
+
+HOST = 'instance'
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(HOST)
+
+
+def pp_json(json_thing, sort=True, indents=2):
+    if type(json_thing) is str:
+        print(json.dumps(json.loads(json_thing), sort_keys=sort, indent=indents))
+    else:
+        print(json.dumps(json_thing, sort_keys=sort, indent=indents))
+    return None
+
+
+def base_directory():
+    """
+    """
+    cwd = os.getcwd()
+
+    if 'group_vars' in os.listdir(cwd):
+        directory = "../.."
+        molecule_directory = "."
+    else:
+        directory = "."
+        molecule_directory = f"molecule/{os.environ.get('MOLECULE_SCENARIO_NAME')}"
+
+    return directory, molecule_directory
+
+
+def read_ansible_yaml(file_name, role_name):
+    """
+    """
+    read_file = None
+
+    for e in ["yml", "yaml"]:
+        test_file = "{}.{}".format(file_name, e)
+        if os.path.isfile(test_file):
+            read_file = test_file
+            break
+
+    return f"file={read_file} name={role_name}"
+
+
+@pytest.fixture()
+def get_vars(host):
+    """
+        parse ansible variables
+        - defaults/main.yml
+        - vars/main.yml
+        - vars/${DISTRIBUTION}.yaml
+        - molecule/${MOLECULE_SCENARIO_NAME}/group_vars/all/vars.yml
+    """
+    base_dir, molecule_dir = base_directory()
+    distribution = host.system_info.distribution
+    operation_system = None
+
+    if distribution in ['debian', 'ubuntu']:
+        operation_system = "debian"
+    elif distribution in ['redhat', 'ol', 'centos', 'rocky', 'almalinux']:
+        operation_system = "redhat"
+    elif distribution in ['arch', 'artix']:
+        operation_system = f"{distribution}linux"
+
+    # print(" -> {} / {}".format(distribution, os))
+    # print(" -> {}".format(base_dir))
+
+    file_defaults = read_ansible_yaml(f"{base_dir}/defaults/main", "role_defaults")
+    file_vars = read_ansible_yaml(f"{base_dir}/vars/main", "role_vars")
+    file_distibution = read_ansible_yaml(f"{base_dir}/vars/{operation_system}", "role_distibution")
+    file_molecule = read_ansible_yaml(f"{molecule_dir}/group_vars/all/vars", "test_vars")
+    # file_host_molecule = read_ansible_yaml("{}/host_vars/{}/vars".format(base_dir, HOST), "host_vars")
+
+    defaults_vars = host.ansible("include_vars", file_defaults).get("ansible_facts").get("role_defaults")
+    vars_vars = host.ansible("include_vars", file_vars).get("ansible_facts").get("role_vars")
+    distibution_vars = host.ansible("include_vars", file_distibution).get("ansible_facts").get("role_distibution")
+    molecule_vars = host.ansible("include_vars", file_molecule).get("ansible_facts").get("test_vars")
+    # host_vars          = host.ansible("include_vars", file_host_molecule).get("ansible_facts").get("host_vars")
+
+    ansible_vars = defaults_vars
+    ansible_vars.update(vars_vars)
+    ansible_vars.update(distibution_vars)
+    ansible_vars.update(molecule_vars)
+    # ansible_vars.update(host_vars)
+
+    templar = Templar(loader=DataLoader(), variables=ansible_vars)
+    result = templar.template(ansible_vars, fail_on_undefined=False)
+
+    return result
+
+
+def local_facts(host):
+    """
+      return local facts
+    """
+    return host.ansible("setup").get("ansible_facts").get("ansible_local").get("forgejo")
+
+
+@pytest.mark.parametrize("dirs", [
+    "/srv/forgejo/config"
+])
+def test_directories(host, dirs):
+    d = host.file(dirs)
+    assert d.is_directory
+
+
+def test_forgejo_files(host, get_vars):
+    """
+    """
+    distribution = host.system_info.distribution
+    release = host.system_info.release
+
+    print(f"distribution: {distribution}")
+    print(f"release     : {release}")
+
+    version = local_facts(host).get("version")
+
+    install_dir = get_vars.get("forgejo_install_path")
+    defaults_dir = get_vars.get("forgejo_defaults_directory")
+    config_dir = get_vars.get("forgejo_config_dir")
+
+    if 'latest' in install_dir:
+        install_dir = install_dir.replace('latest', version)
+
+    files = []
+    files.append("/usr/bin/forgejo")
+
+    if install_dir:
+        files.append(f"{install_dir}/forgejo")
+    if defaults_dir and not distribution == "artix":
+        files.append(f"{defaults_dir}/forgejo")
+    if config_dir:
+        files.append(f"{config_dir}/forgejo.ini")
+
+    print(files)
+
+    for _file in files:
+        f = host.file(_file)
+        assert f.is_file
+
+
+def test_user(host, get_vars):
+    """
+    """
+    user = get_vars.get("forgejo_system_user", "forgejo")
+    group = get_vars.get("forgejo_system_group", "forgejo")
+
+    assert host.group(group).exists
+    assert host.user(user).exists
+    assert group in host.user(user).groups
+    assert host.user(user).home == "/srv/forgejo"
+
+
+def test_service(host, get_vars):
+    service = host.service("forgejo")
+    assert service.is_enabled
+    assert service.is_running
+
+
+def test_open_port(host, get_vars):
+    for i in host.socket.get_listening_sockets():
+        print(i)
+
+    forgejo_server = get_vars.get("forgejo_server", {})
+
+    print(forgejo_server)
+
+    if isinstance(forgejo_server, dict):
+        forgejo_web = forgejo_server.get("web", {})
+
+        addr = forgejo_web.get("http_addr", "0.0.0.0")
+        port = forgejo_web.get("http_port", "3000")
+
+        listen_address = f"{addr}:{port}"
+    else:
+        listen_address = "0.0.0.0:3000"
+
+    service = host.socket(f"tcp://{listen_address}")
+    assert service.is_listening

--- a/roles/forgejo/tasks/authentications.yml
+++ b/roles/forgejo/tasks/authentications.yml
@@ -6,6 +6,8 @@
   become: true
   bodsch.scm.forgejo_user:
     state: list
+    config: "{{ forgejo_config_dir }}/forgejo.ini"
+    working_dir: "{{ forgejo_working_dir }}"
 
 - name: check forgejo admin user '{{ forgejo_admin_user.username }}'
   remote_user: "{{ forgejo_system_user }}"
@@ -14,6 +16,8 @@
   bodsch.scm.forgejo_user:
     state: check
     username: "{{ forgejo_admin_user.username }}"
+    config: "{{ forgejo_config_dir }}/forgejo.ini"
+    working_dir: "{{ forgejo_working_dir }}"
   register: forgejo_admin_user_present
 
 - name: create admin user
@@ -25,6 +29,8 @@
     username: "{{ forgejo_admin_user.username }}"
     password: "{{ forgejo_admin_user.password }}"
     email: "{{ forgejo_admin_user.email }}"
+    config: "{{ forgejo_config_dir }}/forgejo.ini"
+    working_dir: "{{ forgejo_working_dir }}"
   when:
     - not ansible_check_mode
     - forgejo_admin_user_present.rc == 1
@@ -62,6 +68,8 @@
     bind_password: "{{ forgejo_auths.ldap.bind_password | default(omit) }}"
     attributes_in_bind: "{{ forgejo_auths.ldap.attributes_in_bind | default(omit) }}"
     synchronize_users: "{{ forgejo_auths.ldap.synchronize_users | default(omit) }}"
+    config: "{{ forgejo_config_dir }}/forgejo.ini"
+    working_dir: "{{ forgejo_working_dir }}"
   when:
     - forgejo_auths.ldap is defined
     - forgejo_auths.ldap | count > 0

--- a/roles/forgejo/tasks/install.yml
+++ b/roles/forgejo/tasks/install.yml
@@ -99,6 +99,7 @@
               become: true
               bodsch.scm.forgejo_migrate:
                 config: "{{ forgejo_config_dir }}/forgejo.ini"
+                working_dir: "{{ forgejo_working_dir }}"
 
       rescue:
         - name: delete install directory


### PR DESCRIPTION
This change is enough to make the scenario work in the presence of a  forgejo_config_dir that is not /etc/forgejo

Fixes #17 