### PR TITLE
fix: user and group need to match the configured system values

### DIFF
--- a/roles/forgejo/tasks/configure.yml
+++ b/roles/forgejo/tasks/configure.yml
@@ -95,6 +95,8 @@
   bodsch.scm.forgejo_config:
     config: "{{ forgejo_config_dir }}/forgejo.ini"
     new_config: "{{ forgejo_config_dir }}/forgejo.new"
+    owner: "{{ forgejo_system_user }}"
+    group: "{{ forgejo_system_group }}"
   register: forgejo_config
   notify:
     - restart forgejo


### PR DESCRIPTION
`forgejo_config` will not provision with custom values for `forgejo_system_user` and/or `forgejo_system_group` unless the values are added here.

Tested with a fresh VM and using `git` instead of default `forgejo` user.