### PR TITLE
fix: add missing checksum algorithm setting

### DIFF
--- a/roles/forgejo/docs/storage.md
+++ b/roles/forgejo/docs/storage.md
@@ -21,4 +21,5 @@ forgejo_storage:
   #     location: us-east-1
   #     use_ssl: false
   #     insecure_skip_verify: false
+  #     checksum_algorithm: ""
 ```

--- a/roles/forgejo/templates/conf/forgejo.d/storage.j2
+++ b/roles/forgejo/templates/conf/forgejo.d/storage.j2
@@ -80,5 +80,9 @@ MINIO_USE_SSL = {{ m.use_ssl | bodsch.core.config_bool(true_as='true', false_as=
     {% if m.insecure_skip_verify | default('') | string | length > 0 %}
 MINIO_INSECURE_SKIP_VERIFY = {{ m.insecure_skip_verify | bodsch.core.config_bool(true_as='true', false_as='false') }}
     {% endif %}
+    {% if m.checksum_algorithm | default('') | string | length > 0 and
+          m.checksum_algorithm in ["default", "md5"] %}
+MINIO_CHECKSUM_ALGORITHM = {{ m.checksum_algorithm }}
+    {% endif %}
   {% endfor %}
 {% endif %}

--- a/roles/forgejo/vars/main.yml
+++ b/roles/forgejo/vars/main.yml
@@ -1010,6 +1010,7 @@ forgejo_defaults_storage:
   #     location: us-east-1
   #     use_ssl: false
   #     insecure_skip_verify: false
+  #     checksum_algorithm: ""
 
 forgejo_defaults_task:
   queue_type: ""                                  # channel


### PR DESCRIPTION
`checksum_algorithm` has been added in many other places but somehow got lost in the default storage settings.