### PR TITLE
ADD: remote user for forgejo deployment

### DIFF
--- a/plugins/modules/forgejo_admin_user.py
+++ b/plugins/modules/forgejo_admin_user.py
@@ -67,7 +67,7 @@ notes:
 
 EXAMPLES = r"""
 - name: create admin user
-  remote_user: "{{ forgejo_system_user }}"
+  remote_user: "{{ forgejo_remote_user }}"
   become_user: "{{ forgejo_system_user }}"
   become: true
   bodsch.scm.forgejo_admin_user:

--- a/plugins/modules/forgejo_auth.py
+++ b/plugins/modules/forgejo_auth.py
@@ -167,7 +167,7 @@ options:
 
 EXAMPLES = r"""
 - name: enable ldap authentication
-  remote_user: "{{ forgejo_system_user }}"
+  remote_user: "{{ forgejo_remote_user }}"
   become_user: "{{ forgejo_system_user }}"
   become: true
   bodsch.scm.forgejo_auth:

--- a/plugins/modules/forgejo_migrate.py
+++ b/plugins/modules/forgejo_migrate.py
@@ -70,7 +70,7 @@ notes:
 
 EXAMPLES = r"""
 - name: migrate forgejo database
-  remote_user: "{{ forgejo_system_user }}"
+  remote_user: "{{ forgejo_remote_user }}"
   become_user: "{{ forgejo_system_user }}"
   become: true
   bodsch.scm.forgejo_migrate:

--- a/roles/forgejo/README.md
+++ b/roles/forgejo/README.md
@@ -96,6 +96,7 @@ Tested on
 forgejo_version: 1.20.5-0
 
 forgejo_system_user: forgejo
+forgejo_remote_user: forgejo
 forgejo_system_group: forgejo
 forgejo_config_dir: /etc/forgejo
 forgejo_working_dir: /var/lib/forgejo

--- a/roles/forgejo/defaults/main.yml
+++ b/roles/forgejo/defaults/main.yml
@@ -3,6 +3,7 @@
 forgejo_version: 9.0.3
 
 forgejo_system_user: forgejo
+forgejo_remote_user: forgejo
 forgejo_system_group: forgejo
 forgejo_config_dir: /etc/forgejo
 forgejo_working_dir: /var/lib/forgejo

--- a/roles/forgejo/handlers/main.yml
+++ b/roles/forgejo/handlers/main.yml
@@ -25,7 +25,7 @@
     - ansible_service_mgr | lower == "systemd"
 
 - name: migrate forgejo database
-  remote_user: "{{ forgejo_system_user }}"
+  remote_user: "{{ forgejo_remote_user }}"
   become_user: "{{ forgejo_system_user }}"
   become: true
   bodsch.scm.forgejo_migrate:

--- a/roles/forgejo/tasks/authentications.yml
+++ b/roles/forgejo/tasks/authentications.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: create admin user
-  remote_user: "{{ forgejo_system_user }}"
+  remote_user: "{{ forgejo_remote_user }}"
   become_user: "{{ forgejo_system_user }}"
   become: true
   bodsch.scm.forgejo_admin_user:
@@ -26,7 +26,7 @@
     - forgejo_users | default([]) | count > 0
 
 - name: enable ldap authentication
-  remote_user: "{{ forgejo_system_user }}"
+  remote_user: "{{ forgejo_remote_user }}"
   become_user: "{{ forgejo_system_user }}"
   become: true
   bodsch.scm.forgejo_auth:

--- a/roles/forgejo/tasks/install.yml
+++ b/roles/forgejo/tasks/install.yml
@@ -94,7 +94,7 @@
               ansible.builtin.meta: flush_handlers
 
             - name: migrate forgejo database
-              remote_user: "{{ forgejo_system_user }}"
+              remote_user: "{{ forgejo_remote_user }}"
               become_user: "{{ forgejo_system_user }}"
               become: true
               bodsch.scm.forgejo_migrate:


### PR DESCRIPTION
The same situation as with forgejo_runner, the system_user could differ from the remote_user. ref.: #38 

Unfortunately, I was unable to find a suitable documentation section for this, as I did for the other PR. Perhaps you have a tip for me?
Please have a look and let my know if something is missing.