### PR TITLE
fix: use stable hostnames for delegation

### DIFF
--- a/roles/forgejo/tasks/download.yml
+++ b/roles/forgejo/tasks/download.yml
@@ -28,7 +28,7 @@
 
 - name: define delegate instance for download handling
   ansible.builtin.set_fact:
-    forgejo_delegate_to: "{{ ansible_facts.host }}"
+    forgejo_delegate_to: "{{ inventory_hostname }}"
     forgejo_local_tmp_directory: "{{
         lookup('env', 'CUSTOM_LOCAL_TMP_DIRECTORY') |
         default('/var/cache/ansible/forgejo', true) }}/{{ forgejo_version }}"

--- a/roles/forgejo_runner/tasks/download.yml
+++ b/roles/forgejo_runner/tasks/download.yml
@@ -6,7 +6,7 @@
 
 - name: define delegate instance for download handling
   ansible.builtin.set_fact:
-    forgejo_runner_delegate_to: "{{ ansible_facts.host }}"
+    forgejo_runner_delegate_to: "{{ inventory_hostname }}"
     forgejo_runner_local_tmp_directory: "{{
         lookup('env', 'CUSTOM_LOCAL_TMP_DIRECTORY') |
         default('/var/cache/ansible/forgejo', true) }}/{{ forgejo_runner_version }}"

--- a/roles/opengist/tasks/download.yml
+++ b/roles/opengist/tasks/download.yml
@@ -28,7 +28,7 @@
 
 - name: define delegate instance for download handling
   ansible.builtin.set_fact:
-    opengist_delegate_to: "{{ ansible_facts.host }}"
+    opengist_delegate_to: "{{ inventory_hostname }}"
     opengist_local_tmp_directory: "{{
         lookup('env', 'CUSTOM_LOCAL_TMP_DIRECTORY') |
         default('/var/cache/ansible/opengist', true) }}/{{ opengist_version }}"


### PR DESCRIPTION
During a recent deployment I noticed that host delegation uses `ansible_facts.host` which seems to not work with older versions. This is on Ansible 2.18.x

This changes restores the delegation to work with older releases. Not sure if this is a bug or just a newer Ansible feature I have missed.